### PR TITLE
improves testing on sunny sorter

### DIFF
--- a/spec/interactors/sunny_episodes/index_spec.rb
+++ b/spec/interactors/sunny_episodes/index_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SunnyEpisodes::Index, type: :interactor do
   subject(:context) { described_class.call(params) }
 
   let(:user) { create(:user) }
+  let(:user_without_rankings) { create(:user) }
   let(:params) { { user: } }
 
   let!(:excellent_episode) { create(:sunny_episode, title: 'The Gang Runs for Office') }
@@ -13,22 +14,38 @@ RSpec.describe SunnyEpisodes::Index, type: :interactor do
   let!(:bad_episode)       { create(:sunny_episode, title: 'The Gang Goes on Family Fight') }
   let!(:terrible_epsiode)  { create(:sunny_episode, title: 'The Gang Goes to Ireland') }
 
-  before do
-    create_list(:sunny_episode_user_ranking, 50, user:, better_episode: excellent_episode, worse_episode: bad_episode)
-    create_list(:sunny_episode_user_ranking, 50, user:, better_episode: ok_episode, worse_episode: bad_episode)
-    create_list(:sunny_episode_user_ranking, 50, user:, better_episode: bad_episode, worse_episode: terrible_epsiode)
-  end
-
   describe '.call' do
-    it 'succeeds' do
-      expect(context).to be_a_success
+    before do
+      create_list(:sunny_episode_user_ranking, 50, user:, better_episode: excellent_episode, worse_episode: bad_episode)
+      create_list(:sunny_episode_user_ranking, 50, user:, better_episode: ok_episode, worse_episode: bad_episode)
+      create_list(:sunny_episode_user_ranking, 50, user:, better_episode: bad_episode, worse_episode: terrible_epsiode)
     end
 
-    it 'returns top ten episodes', :aggregate_failures do
-      expect(context.top_hundred).to all(be_a(SunnyEpisode))
-      expect(context.top_hundred.size).to be(3)
-      expect(context.top_hundred_by_user).to all(be_a(SunnyEpisode))
-      expect(context.top_hundred_by_user.size).to be(3)
+    context 'when user has rankings' do
+      it 'succeeds' do
+        expect(context).to be_a_success
+      end
+
+      it 'returns top episodes information for public and user', :aggregate_failures do
+        expect(context.top_hundred).to all(be_a(SunnyEpisode))
+        expect(context.top_hundred.size).to be(3)
+        expect(context.top_hundred_by_user).to all(be_a(SunnyEpisode))
+        expect(context.top_hundred_by_user.size).to be(3)
+      end
+    end
+
+    context 'when user has no rankings' do
+      let(:params) { { user: user_without_rankings } }
+
+      it 'succeeds' do
+        expect(context).to be_a_success
+      end
+
+      it 'returns top episodes information for public and user', :aggregate_failures do
+        expect(context.top_hundred).to all(be_a(SunnyEpisode))
+        expect(context.top_hundred.size).to be(3)
+        expect(context.top_hundred_by_user).to eq([])
+      end
     end
   end
 end

--- a/spec/requests/api/v1/sunny_episode_user_rankings_spec.rb
+++ b/spec/requests/api/v1/sunny_episode_user_rankings_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe 'Api::V1::SunnyEpisodeUserRankings' do
   include RequestSpecHelper
 
-  let!(:user) { create(:user, password:) }
+  let(:user) { create(:user, password:) }
   let!(:bad_episode) { create(:sunny_episode, title: "Paddy's Has a Jumper") }
   let!(:good_episode) { create(:sunny_episode, title: 'The Gang Beats Boggs') }
 
@@ -14,9 +14,17 @@ RSpec.describe 'Api::V1::SunnyEpisodeUserRankings' do
   let(:token) { login_user_for_token(user.username, password) }
 
   describe 'GET /index' do
+    before { get(api_v1_sunny_episode_user_rankings_path, headers:) }
+
     it 'returns http success' do
-      get(api_v1_sunny_episode_user_rankings_path, headers:)
       expect(response).to have_http_status(:success)
+    end
+
+    it 'returns a collection of data' do
+      expect(data).to match([
+                              a_kind_of(Hash),
+                              a_kind_of(Hash)
+                            ])
     end
   end
 


### PR DESCRIPTION
## PR Guidelines
* Keep it concise. A small, in-scope, easy to review pull request is always preferred over bulkier more complex ones. It's ok to split your work effort into more that one PR if you think it will make things easier on the reviewers.
* Provide a thorough description. Explain what your changes do in as simple terms as possible. Give examples of behavior or illustrate with images or diagrams.
* Don't rewrite Git history once other people have seen your PR. This is important for making sure reviewers have a clean picture of your changes.
* We don't enforce signed commits but many employers do so they know the PR came from you. Feel free to [setup signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) if you wish. 
* Don't merge someone elses PR unless asked to or the author is unavailable.

## Proposed changes

Describe the big picture of your changes here to communicate to the team why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Refactor (found a better way to write the code and accomplish the same task)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
